### PR TITLE
Add cached key provider, add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ aws-smithy-client = { version = "0.40.2", features = [ "test-util" ] }
 aws-smithy-http = "0.40.2"
 http = "0.2"
 base64 = "0.13.0"
+futures = "0.3.21"
+itertools = "0.10.3"
 
 [dependencies]
 aes-gcm = "0.9.4"
@@ -27,3 +29,5 @@ serde_cbor = "0.11.2"
 thiserror = "1.0.30"
 async-trait = "0.1.53"
 aws-sdk-kms = "0.10.1"
+lru = "0.7.5"
+zeroize = { version = "1.5.5", features = [ "zeroize_derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@ a `SimpleKeyProvider` that can be used with a local key.
 
 **NOTE: This library is very alpha and not yet suitable for production use**
 
+## Examples
 
+### AWS Key Management Service
+
+In order to run the AWS KMS examples you need to ensure the correct environment variables or config options are set to connect to your AWS account.
+
+Follow the AWS [getting started](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/getting-started.html) docs for help.

--- a/examples/kms-multiple-entries.rs
+++ b/examples/kms-multiple-entries.rs
@@ -1,0 +1,95 @@
+use aws_sdk_kms::Client;
+use envelopers::{CacheOptions, EnvelopeCipher, KMSKeyProvider};
+use futures::future::join_all;
+use itertools::Itertools;
+use rand::{distributions::Alphanumeric, Rng};
+use std::{error::Error, fmt::Debug, future::Future, iter::IntoIterator, time::Duration};
+
+const MESSAGE_COUNT: usize = 1_000;
+const MESSAGE_SIZE_BYTES: usize = 1024;
+const MAX_PARALLEL_REQS: usize = 10;
+
+async fn join_all_with_chunks<T, U: Debug, F: Future<Output = Result<T, U>>>(
+    futures: Vec<F>,
+    chunk_size: usize,
+) -> Vec<T> {
+    let mut output = Vec::with_capacity(futures.len());
+
+    for chunk in futures.into_iter().chunks(chunk_size).into_iter() {
+        output.extend(join_all(chunk).await.into_iter().map(|x| x.unwrap()));
+    }
+
+    output
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::new(&aws_config::from_env().load().await);
+
+    let provider = KMSKeyProvider::new(
+        client,
+        std::env::var("CS_KEY_ID")
+            .expect("Please export CS_KEY_ID environment variable with your AWS KMS key id."),
+    );
+
+    let cipher: EnvelopeCipher<KMSKeyProvider> = EnvelopeCipher::init(
+        provider,
+        CacheOptions::default()
+            .with_max_age(Duration::from_secs(30))
+            .with_max_bytes(10 * 1024)
+            .with_max_messages(100)
+            .with_max_entries(100),
+    );
+
+    let data: Vec<String> = (0..MESSAGE_COUNT)
+        .map(|_| {
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(MESSAGE_SIZE_BYTES)
+                .map(char::from)
+                .collect()
+        })
+        .collect();
+
+    let encryption_start = std::time::Instant::now();
+
+    println!("Starting encryptions!");
+
+    let encrypted = join_all_with_chunks(
+        data.iter()
+            .map(|message| cipher.encrypt(message.as_bytes()))
+            .collect(),
+        MAX_PARALLEL_REQS,
+    )
+    .await;
+
+    println!(
+        "Encryption took {} seconds",
+        encryption_start.elapsed().as_secs()
+    );
+
+    let decryption_start = std::time::Instant::now();
+
+    let decrypted = join_all_with_chunks(
+        encrypted
+            .iter()
+            .map(|record| cipher.decrypt(record))
+            .collect(),
+        MAX_PARALLEL_REQS,
+    )
+    .await
+    .into_iter()
+    .map(|x| String::from_utf8(x).unwrap())
+    .collect::<Vec<_>>();
+
+    println!(
+        "Decryption took {} seconds",
+        decryption_start.elapsed().as_secs()
+    );
+
+    assert_eq!(data.len(), decrypted.len());
+
+    assert_eq!(data, decrypted);
+
+    Ok(())
+}

--- a/examples/kms.rs
+++ b/examples/kms.rs
@@ -5,6 +5,18 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    // Load the AWS KMS client from the local environment.
+    //
+    // If using AWS secret keys, ensure your credentials are set in ~/.aws/credentials,
+    // or set the following environment variables:
+    // - AWS_ACCESS_KEY_ID
+    // - AWS_SECRET_ACCESS_KEY
+    //
+    // Alternatively, if using AWS STS set the following environment variables:
+    // - AWS_SECRET_ACCESS_KEY
+    // - AWS_SESSION_TOKEN
+    // - AWS_ACCESS_KEY_ID
+    // - AWS_REGION
     let client = Client::new(&aws_config::from_env().load().await);
 
     let provider = KMSKeyProvider::new(client, std::env::var("CS_KEY_ID")?);

--- a/examples/kms.rs
+++ b/examples/kms.rs
@@ -1,6 +1,7 @@
 use aws_sdk_kms::Client;
-use envelopers::{EnvelopeCipher, KMSKeyProvider};
+use envelopers::{CacheOptions, EnvelopeCipher, KMSKeyProvider};
 use std::error::Error;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -8,9 +9,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let provider = KMSKeyProvider::new(client, std::env::var("CS_KEY_ID")?);
 
-    let cipher: EnvelopeCipher<KMSKeyProvider> = EnvelopeCipher::init(provider);
+    let cipher: EnvelopeCipher<KMSKeyProvider> = EnvelopeCipher::init(
+        provider,
+        CacheOptions::default()
+            .with_max_age(Duration::from_secs(30))
+            .with_max_bytes(100 * 1024)
+            .with_max_messages(10)
+            .with_max_entries(10),
+    );
 
-    let encrypted = cipher.encrypt("This is a great test string!".as_bytes()).await?;
+    let encrypted = cipher
+        .encrypt("This is a great test string!".as_bytes())
+        .await?;
 
     let decrypted = cipher.decrypt(&encrypted).await?;
 

--- a/src/caching_key_wrapper.rs
+++ b/src/caching_key_wrapper.rs
@@ -1,0 +1,266 @@
+use aes_gcm::aes::cipher::consts::U16;
+use aes_gcm::Key;
+use lru::LruCache;
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
+use zeroize::ZeroizeOnDrop;
+
+use crate::errors::{KeyDecryptionError, KeyGenerationError};
+use crate::key_provider::DataKey;
+use crate::KeyProvider;
+
+#[derive(ZeroizeOnDrop)]
+struct CachedEncryptionEntry {
+    #[zeroize(skip)]
+    created_at: Instant,
+    key: DataKey,
+    bytes_encrypted: usize,
+    messages_encrypted: usize,
+}
+
+#[derive(ZeroizeOnDrop)]
+struct CachedDecryptionEntry {
+    key: Key<U16>,
+    #[zeroize(skip)]
+    created_at: Instant,
+}
+
+/// The options for configuring a [`CachingKeyWrapper`]'s cache
+pub struct CacheOptions {
+    max_age: Duration,
+    max_bytes: usize,
+    max_messages: usize,
+    max_entries: usize,
+}
+
+impl CacheOptions {
+    /// Configure the maximum time a key can remain in the cache
+    pub fn with_max_age(mut self, max_age: Duration) -> Self {
+        self.max_age = max_age;
+        self
+    }
+
+    /// Configure the maximum number of bytes a key can encrypt
+    pub fn with_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// Configure the maximum number of messages a key can encrypt
+    pub fn with_max_messages(mut self, max_messages: usize) -> Self {
+        self.max_messages = max_messages;
+        self
+    }
+
+    /// Configure the maximum number of keys that can be in the cache
+    pub fn with_max_entries(mut self, max_entries: usize) -> Self {
+        self.max_entries = max_entries;
+        self
+    }
+}
+
+impl Default for CacheOptions {
+    fn default() -> Self {
+        // These defaults are based on the aws-encryption-sdk-javascript examples
+        Self {
+            max_age: Duration::from_secs(60),
+            max_bytes: 100,
+            max_messages: 10,
+            max_entries: 10,
+        }
+    }
+}
+
+/// A wrapper for a [`KeyProvider`] that supports caching.
+///
+/// Caching can be configured using [`CacheOptions`] to work based on:
+/// - max messages encrypted per key
+/// - max bytes encrypted per key
+/// - max time key can be cached for
+pub struct CachingKeyWrapper<K> {
+    encryption_cache: RefCell<Vec<CachedEncryptionEntry>>,
+    decryption_cache: RefCell<LruCache<Vec<u8>, CachedDecryptionEntry>>,
+    options: CacheOptions,
+    provider: K,
+}
+
+impl<K> CachingKeyWrapper<K>
+where
+    K: KeyProvider,
+{
+    /// Create a new CachingKeyWrapper from a certain key provider and caching options
+    pub fn new(provider: K, options: CacheOptions) -> Self {
+        Self {
+            provider,
+            decryption_cache: RefCell::new(LruCache::new(options.max_entries)),
+            encryption_cache: Default::default(),
+            options,
+        }
+    }
+
+    fn has_exceeded_limits(&self, entry: &CachedEncryptionEntry) -> bool {
+        entry.created_at.elapsed() > self.options.max_age
+            || entry.messages_encrypted > self.options.max_messages
+            || entry.bytes_encrypted > self.options.max_bytes
+    }
+
+    fn maybe_prune_last_decryption_entry(
+        &self,
+        cache: &mut LruCache<Vec<u8>, CachedDecryptionEntry>,
+    ) {
+        let should_pop = cache
+            .peek_lru()
+            .map(|(_, entry)| entry.created_at.elapsed() > self.options.max_age)
+            .unwrap_or(false);
+
+        if should_pop {
+            let popped = cache.pop_lru();
+            // Zero out old data key here?
+            drop(popped);
+        }
+    }
+
+    fn get_and_increment_cached_encryption_key(
+        &self,
+        bytes: usize,
+    ) -> Result<Option<DataKey>, KeyGenerationError> {
+        let mut cached = self
+            .encryption_cache
+            .try_borrow_mut()
+            .map_err(|_| KeyGenerationError::Other("Failed to borrow cached key".into()))?;
+
+        while let Some(mut cached_entry) = cached.pop() {
+            cached_entry.messages_encrypted += 1;
+            cached_entry.bytes_encrypted += bytes;
+
+            if !self.has_exceeded_limits(&cached_entry) {
+                // Cloning here could be bad for zeroing memory + performance.
+                // Maybe change this method to be a "with_data_key_for_bytes" so that
+                // we can borrow the key instead.
+                let key = cached_entry.key.clone();
+
+                // Since the entry is fine to keep, add it back to the stack
+                cached.push(cached_entry);
+
+                return Ok(Some(key));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn get_cached_decryption_key(
+        &self,
+        encrypted_key: &Vec<u8>,
+    ) -> Result<Option<Key<U16>>, KeyDecryptionError> {
+        let mut decryption_cache = self
+            .decryption_cache
+            .try_borrow_mut()
+            .map_err(|_| KeyDecryptionError::Other("Failed to borrow decryption cache".into()))?;
+
+        if let Some(cached_key) = decryption_cache.get(encrypted_key) {
+            // Only return the cached key if the age is less than the max_age param.
+            // I don't think this is strictly necessary, but it's what the JS AWS SDK does.
+            if cached_key.created_at.elapsed() <= self.options.max_age {
+                return Ok(Some(cached_key.key));
+            }
+        }
+
+        self.maybe_prune_last_decryption_entry(&mut decryption_cache);
+
+        Ok(None)
+    }
+
+    fn cache_encryption_key(&self, bytes: usize, key: DataKey) -> Result<(), KeyGenerationError> {
+        let mut cached = self
+            .encryption_cache
+            .try_borrow_mut()
+            .map_err(|_| KeyGenerationError::Other("Failed to borrow cached key".into()))?;
+
+        // If the encryption cache has too many entries, remove the first one.
+        // This operation needs to shift all the elements in the Vec, but should
+        // be negligible since the "max_entries" option on the cache will most
+        // likely be <1000.
+        if cached.len() >= self.options.max_entries {
+            cached.remove(0);
+        }
+
+        cached.push(CachedEncryptionEntry {
+            key: key.clone(),
+            bytes_encrypted: bytes,
+            messages_encrypted: 1,
+            created_at: Instant::now(),
+        });
+
+        let mut decryption_cache = self
+            .decryption_cache
+            .try_borrow_mut()
+            .map_err(|_| KeyGenerationError::Other("Failed to borrow decryption cache".into()))?;
+
+        self.maybe_prune_last_decryption_entry(&mut decryption_cache);
+
+        decryption_cache.put(
+            key.encrypted_key.clone(),
+            CachedDecryptionEntry {
+                key: key.key,
+                created_at: Instant::now(),
+            },
+        );
+
+        Ok(())
+    }
+
+    fn cache_decryption_key(
+        &self,
+        encrypted_key: &Vec<u8>,
+        plaintext_key: Key<U16>,
+    ) -> Result<(), KeyDecryptionError> {
+        self.decryption_cache
+            .try_borrow_mut()
+            .map_err(|_| KeyDecryptionError::Other("Failed to borrow decryption cache".into()))?
+            .put(
+                // Sucks that you have to clone here - surely they can hash from a reference
+                encrypted_key.clone(),
+                CachedDecryptionEntry {
+                    key: plaintext_key,
+                    created_at: Instant::now(),
+                },
+            );
+
+        Ok(())
+    }
+
+    /// Get a cached data key or generate one for a certain number of bytes
+    ///
+    /// Note: the bytes field is used to determine when keys should be expired. It's important that
+    /// this is the number of bytes the key will be used to encrypt.
+    pub async fn get_or_generate_data_key_for_bytes(
+        &self,
+        bytes: usize,
+    ) -> Result<DataKey, KeyGenerationError> {
+        if let Some(cached_key) = self.get_and_increment_cached_encryption_key(bytes)? {
+            return Ok(cached_key);
+        }
+
+        let key = self.provider.generate_data_key().await?;
+
+        self.cache_encryption_key(bytes, key.clone())?;
+
+        Ok(key)
+    }
+
+    pub async fn decrypt_data_key(
+        &self,
+        encrypted_key: &Vec<u8>,
+    ) -> Result<Key<U16>, KeyDecryptionError> {
+        if let Some(cached_key) = self.get_cached_decryption_key(encrypted_key)? {
+            return Ok(cached_key);
+        }
+
+        let plaintext_key = self.provider.decrypt_data_key(encrypted_key).await?;
+
+        self.cache_decryption_key(encrypted_key, plaintext_key)?;
+
+        Ok(plaintext_key)
+    }
+}

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -3,10 +3,11 @@
 use aes_gcm::aes::cipher::consts::U16;
 use aes_gcm::Key;
 use async_trait::async_trait;
+use zeroize::Zeroize;
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Zeroize)]
 pub struct DataKey {
     pub key: Key<U16>,
     // TODO: Maybe make a type for EncryptedKey

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -118,7 +118,7 @@ impl KeyProvider for KMSKeyProvider {
 
 #[cfg(test)]
 mod tests {
-    use tokio;
+    
 
     use aws_sdk_kms::{Client, Config, Credentials, Region};
     use aws_smithy_client::test_connection::TestConnection;

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -92,7 +92,7 @@ impl<R: SeedableRng + RngCore> KeyProvider for SimpleKeyProvider<R> {
         let key = Key::from_slice(&self.kek);
         let cipher = AesGcm::<Aes128, U16>::new(key);
 
-        let decoded_key = EncryptedSimpleKey::from_slice(&encrypted_key)?;
+        let decoded_key = EncryptedSimpleKey::from_slice(encrypted_key)?;
 
         let data_key = cipher.decrypt(
             decoded_key.nonce,
@@ -140,7 +140,7 @@ impl<R: SeedableRng + RngCore> KeyProvider for SimpleKeyProvider<R> {
 
 #[cfg(test)]
 mod tests {
-    use tokio;
+    
 
     use super::{EncryptedSimpleKey, Nonce};
     use crate::{key_provider::DataKey, KeyProvider, SimpleKeyProvider};


### PR DESCRIPTION
First pass at adding a caching key provider. I just made the cache a part of the envelope cipher instead of making it a "higher order" key provider since the cache needs to know how many bytes were used. Happy to make this part of the key provider trait if that's better.

I've put up a discuss topic to talk about different caching options and considerations, please take a look if you get a chance: https://discuss.cipherstash.com/t/enveloper-caching-behaviour/79/2

- [x] write some tests
- [x] add docs on how to run examples

Performance numbers:

- No parallel reqs, no caching: 40s or so
- 10 parallel reqs max, no caching:  4s
- No parallel reqs, caching: 4s (around 10 messages per key, 100 messages per key is almost instant)
- 10 parallel reqs and it's instant up to 10k records or so