### PR TITLE
Add retry config to KMS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.1]
+
+## Changed
+
+- Increased retry config to 5 attempts
+
 ## [0.4.0]
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use aws_config::RetryConfig;
 use aws_sdk_kms::model::DataKeySpec;
 use aws_sdk_kms::types::Blob;
 use aws_sdk_kms::{Client, Config, Credentials, Region};
@@ -44,6 +45,7 @@ impl KMSKeyProvider {
         let config = Config::builder()
             .region(Region::new(region.into()))
             .credentials_provider(aws_creds)
+            .retry_config(RetryConfig::new().with_max_attempts(5))
             .build();
 
         let client = Client::from_conf(config);
@@ -118,7 +120,6 @@ impl KeyProvider for KMSKeyProvider {
 
 #[cfg(test)]
 mod tests {
-    
 
     use aws_sdk_kms::{Client, Config, Credentials, Region};
     use aws_smithy_client::test_connection::TestConnection;

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -140,7 +140,6 @@ impl<R: SeedableRng + RngCore> KeyProvider for SimpleKeyProvider<R> {
 
 #[cfg(test)]
 mod tests {
-    
 
     use super::{EncryptedSimpleKey, Nonce};
     use crate::{key_provider::DataKey, KeyProvider, SimpleKeyProvider};


### PR DESCRIPTION
Adds a RetryConfig with 5 attempts to the KMS SDK to try and fix some flakes.

Not sure if this will fix the issue but I figured I'd try this before creating custom retry logic.