### PR TITLE
Update KeyProvider, make CachingKeyWrapper a provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- Updated `KeyProvider` trait to pass through bytes to be encrypted
+- Updated `CachingKeyWrapper` to implement `KeyProvider`
+- Made `aws-kms` and `cache` features on by default
+
 ## [0.4.1]
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ base64 = "0.13.0"
 futures = "0.3.21"
 itertools = "0.10.3"
 
-aws-config = "0.10.1"
 aws-smithy-client = { version = "0.40.2", features = [ "test-util" ] }
 aws-smithy-http = "0.40.2"
 
@@ -32,10 +31,12 @@ lru = "0.7.5"
 zeroize = { version = "1.5.5", features = [ "zeroize_derive" ] }
 
 aws-sdk-kms = { version = "0.10.1", optional = true }
+aws-config = { version = "0.10.1", optional = true }
 
 [features]
-# Enable the KMS Key Provider
-aws-kms = ["dep:aws-sdk-kms"]
+default = ["aws-kms", "cache"]
+aws-kms = ["dep:aws-sdk-kms", "dep:aws-config"]
+cache = []
 
 [[example]]
 name = "kms"

--- a/examples/kms-benchmark.rs
+++ b/examples/kms-benchmark.rs
@@ -1,12 +1,12 @@
 use aws_sdk_kms::Client;
-use envelopers::{CacheOptions, EnvelopeCipher, KMSKeyProvider};
+use envelopers::{CacheOptions, CachingKeyWrapper, EnvelopeCipher, KMSKeyProvider};
 use futures::future::join_all;
 use itertools::Itertools;
 use rand::{distributions::Alphanumeric, Rng};
 use std::{error::Error, fmt::Debug, future::Future, iter::IntoIterator, time::Duration};
 
 // The number of messages to be encrypted and decrypted
-const MESSAGE_COUNT: usize = 1_000;
+const MESSAGE_COUNT: usize = 10_000;
 
 // The size of the message in characters of each message
 const MESSAGE_SIZE_CHARS: usize = 1024;
@@ -55,14 +55,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .expect("Please export CS_KEY_ID environment variable with your AWS KMS key id."),
     );
 
-    let cipher: EnvelopeCipher<KMSKeyProvider> = EnvelopeCipher::init(
-        provider,
-        CacheOptions::default()
-            .with_max_age(Duration::from_secs(30))
-            .with_max_bytes(10 * 1024)
-            .with_max_messages(100)
-            .with_max_entries(100),
-    );
+    let cipher: EnvelopeCipher<CachingKeyWrapper<KMSKeyProvider>> =
+        EnvelopeCipher::init(CachingKeyWrapper::new(
+            provider,
+            CacheOptions::default()
+                .with_max_age(Duration::from_secs(30))
+                .with_max_bytes(10 * 1024)
+                .with_max_messages(100)
+                .with_max_entries(100),
+        ));
 
     let data: Vec<String> = (0..MESSAGE_COUNT)
         .map(|_| {

--- a/examples/kms-benchmark.rs
+++ b/examples/kms-benchmark.rs
@@ -6,7 +6,7 @@ use rand::{distributions::Alphanumeric, Rng};
 use std::{error::Error, fmt::Debug, future::Future, iter::IntoIterator, time::Duration};
 
 // The number of messages to be encrypted and decrypted
-const MESSAGE_COUNT: usize = 10_000;
+const MESSAGE_COUNT: usize = 1_000;
 
 // The size of the message in characters of each message
 const MESSAGE_SIZE_CHARS: usize = 1024;

--- a/examples/kms.rs
+++ b/examples/kms.rs
@@ -1,5 +1,5 @@
 use aws_sdk_kms::Client;
-use envelopers::{CacheOptions, EnvelopeCipher, KMSKeyProvider};
+use envelopers::{CacheOptions, CachingKeyWrapper, EnvelopeCipher, KMSKeyProvider};
 use std::error::Error;
 use std::time::Duration;
 
@@ -21,14 +21,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let provider = KMSKeyProvider::new(client, std::env::var("CS_KEY_ID")?);
 
-    let cipher: EnvelopeCipher<KMSKeyProvider> = EnvelopeCipher::init(
-        provider,
-        CacheOptions::default()
-            .with_max_age(Duration::from_secs(30))
-            .with_max_bytes(100 * 1024)
-            .with_max_messages(10)
-            .with_max_entries(10),
-    );
+    let cipher: EnvelopeCipher<CachingKeyWrapper<KMSKeyProvider>> =
+        EnvelopeCipher::init(CachingKeyWrapper::new(
+            provider,
+            CacheOptions::default()
+                .with_max_age(Duration::from_secs(30))
+                .with_max_bytes(100 * 1024)
+                .with_max_messages(10)
+                .with_max_entries(10),
+        ));
 
     let encrypted = cipher
         .encrypt("This is a great test string!".as_bytes())

--- a/src/caching_key_wrapper.rs
+++ b/src/caching_key_wrapper.rs
@@ -327,7 +327,7 @@ mod tests {
             Ok(Key::clone_from_slice(&test_decrypt_bytes(encrypted_key)))
         }
 
-        async fn generate_data_key(&self, _bytes: usize) -> Result<DataKey, KeyGenerationError> {
+        async fn generate_data_key(&self, _bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError> {
             let count = self.generate_counter.fetch_add(1, Ordering::Relaxed);
             // Generate a data key that is just the current count for all bytes
             let key = Key::clone_from_slice(&[count; 16]);

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -17,7 +17,14 @@ pub struct DataKey {
 
 #[async_trait(?Send)]
 pub trait KeyProvider {
-    async fn generate_data_key(&self, bytes: usize) -> Result<DataKey, KeyGenerationError>;
+    /// Generate a [`DataKey`] to encrypt a specific number of bytes
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes_to_encrypt` - The number of bytes that this key will be used to encrypt
+    ///
+    async fn generate_data_key(&self, bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError>;
+    /// Decrypt an encrypted key and return the plaintext key
     async fn decrypt_data_key(
         &self,
         encrypted_key: &Vec<u8>,
@@ -26,8 +33,8 @@ pub trait KeyProvider {
 
 #[async_trait(?Send)]
 impl KeyProvider for Box<dyn KeyProvider> {
-    async fn generate_data_key(&self, bytes: usize) -> Result<DataKey, KeyGenerationError> {
-        (**self).generate_data_key(bytes).await
+    async fn generate_data_key(&self, bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError> {
+        (**self).generate_data_key(bytes_to_encrypt).await
     }
 
     async fn decrypt_data_key(

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -17,7 +17,7 @@ pub struct DataKey {
 
 #[async_trait(?Send)]
 pub trait KeyProvider {
-    async fn generate_data_key(&self) -> Result<DataKey, KeyGenerationError>;
+    async fn generate_data_key(&self, bytes: usize) -> Result<DataKey, KeyGenerationError>;
     async fn decrypt_data_key(
         &self,
         encrypted_key: &Vec<u8>,
@@ -26,8 +26,8 @@ pub trait KeyProvider {
 
 #[async_trait(?Send)]
 impl KeyProvider for Box<dyn KeyProvider> {
-    async fn generate_data_key(&self) -> Result<DataKey, KeyGenerationError> {
-        (**self).generate_data_key().await
+    async fn generate_data_key(&self, bytes: usize) -> Result<DataKey, KeyGenerationError> {
+        (**self).generate_data_key(bytes).await
     }
 
     async fn decrypt_data_key(

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use aws_config::RetryConfig;
 use aws_sdk_kms::model::DataKeySpec;
 use aws_sdk_kms::types::Blob;
 use aws_sdk_kms::{Client, Config, Credentials, Region};
+use aws_config::RetryConfig;
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
 use crate::key_provider::{DataKey, KeyProvider};
@@ -61,7 +61,7 @@ impl KMSKeyProvider {
 
 #[async_trait(?Send)]
 impl KeyProvider for KMSKeyProvider {
-    async fn generate_data_key(&self) -> Result<DataKey, KeyGenerationError> {
+    async fn generate_data_key(&self, _bytes: usize) -> Result<DataKey, KeyGenerationError> {
         let mut response = self
             .client
             .generate_data_key()
@@ -190,7 +190,7 @@ mod tests {
                 let provider = KMSKeyProvider::new(client, key_id.into());
 
                 let key = provider
-                    .generate_data_key()
+                    .generate_data_key(0)
                     .await
                     .expect("Failed to generate data key");
 
@@ -213,7 +213,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::new(client, key_id.into());
 
-                let result = provider.generate_data_key().await;
+                let result = provider.generate_data_key(0).await;
 
                 assert_eq!(
                     result
@@ -242,7 +242,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::new(client, key_id.into());
 
-                let result = provider.generate_data_key().await;
+                let result = provider.generate_data_key(0).await;
 
                 assert_eq!(
                     result
@@ -272,7 +272,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::new(client, key_id.into());
 
-                let result = provider.generate_data_key().await;
+                let result = provider.generate_data_key(0).await;
 
                 assert_eq!(
                     result
@@ -296,7 +296,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::new(client, key_id.into());
 
-                let result = provider.generate_data_key().await;
+                let result = provider.generate_data_key(0).await;
 
                 assert_eq!(
                     result

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -61,7 +61,7 @@ impl KMSKeyProvider {
 
 #[async_trait(?Send)]
 impl KeyProvider for KMSKeyProvider {
-    async fn generate_data_key(&self, _bytes: usize) -> Result<DataKey, KeyGenerationError> {
+    async fn generate_data_key(&self, _bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError> {
         let mut response = self
             .client
             .generate_data_key()

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -105,7 +105,7 @@ impl<R: SeedableRng + RngCore> KeyProvider for SimpleKeyProvider<R> {
         return Ok(*Key::from_slice(&data_key));
     }
 
-    async fn generate_data_key(&self) -> Result<DataKey, KeyGenerationError> {
+    async fn generate_data_key(&self, _bytes: usize) -> Result<DataKey, KeyGenerationError> {
         let key = Key::from_slice(&self.kek);
         let cipher = AesGcm::<Aes128, U16>::new(key);
 
@@ -154,7 +154,7 @@ mod tests {
 
         let DataKey {
             encrypted_key, key, ..
-        } = provider.generate_data_key().await.unwrap();
+        } = provider.generate_data_key(0).await.unwrap();
 
         assert_eq!(
             key,
@@ -168,7 +168,7 @@ mod tests {
 
         let DataKey {
             encrypted_key, key, ..
-        } = provider.generate_data_key().await.unwrap();
+        } = provider.generate_data_key(0).await.unwrap();
 
         assert_eq!(
             key,
@@ -182,7 +182,7 @@ mod tests {
 
         let second: SimpleKeyProvider = SimpleKeyProvider::init([1; 16]);
 
-        let DataKey { encrypted_key, .. } = first.generate_data_key().await.unwrap();
+        let DataKey { encrypted_key, .. } = first.generate_data_key(0).await.unwrap();
 
         assert_eq!(
             second
@@ -200,7 +200,7 @@ mod tests {
 
         let DataKey {
             mut encrypted_key, ..
-        } = provider.generate_data_key().await.unwrap();
+        } = provider.generate_data_key(0).await.unwrap();
 
         // Decrypts data key fine
         assert!(provider.decrypt_data_key(&encrypted_key).await.is_ok());
@@ -225,7 +225,7 @@ mod tests {
 
         let DataKey {
             mut encrypted_key, ..
-        } = provider.generate_data_key().await.unwrap();
+        } = provider.generate_data_key(0).await.unwrap();
 
         // Decrypts data key fine
         assert!(provider.decrypt_data_key(&encrypted_key).await.is_ok());


### PR DESCRIPTION
Updates the `KeyProvider` struct to take the number of bytes to be encrypted and turns `CachingKeyWrapper` into a `KeyProvider`.
