### PR TITLE
Add tokio feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.1]
+
+- Add `tokio` feature which enabled `rt-tokio` in `aws-sdk-kms`
+
 ## [0.5.0]
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
@@ -34,9 +34,10 @@ aws-sdk-kms = { version = "0.10.1", optional = true }
 aws-config = { version = "0.10.1", optional = true }
 
 [features]
-default = ["aws-kms", "cache"]
+default = ["aws-kms", "cache", "tokio"]
 aws-kms = ["dep:aws-sdk-kms", "dep:aws-config"]
 cache = []
+tokio = ["aws-sdk-kms?/rt-tokio"]
 
 [[example]]
 name = "kms"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ aws-sdk-kms = { version = "0.10.1", optional = true }
 aws-config = { version = "0.10.1", optional = true }
 
 [features]
-default = ["aws-kms", "cache", "tokio"]
+default = ["aws-kms", "cache"]
 aws-kms = ["dep:aws-sdk-kms", "dep:aws-config"]
 cache = []
 tokio = ["aws-sdk-kms?/rt-tokio"]


### PR DESCRIPTION
The AWS SDK couldn't retry tasks because it didn't know how it should sleep.

With the `rt-tokio` feature enabled KMS will use `tokio` to sleep which should hopefully make retrying work great.
