### PR TITLE
Make envelope cipher thread safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           cargo test
 
+      - name: "Check no default"
+        run : |
+          cargo check --no-default-features
+
   bench:
     runs-on: ubuntu-latest
     name: "⏱ Benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,12 @@ thiserror = "1.0.30"
 async-trait = "0.1.53"
 lru = "0.7.5"
 zeroize = { version = "1.5.5", features = [ "zeroize_derive" ] }
+static_assertions = "1.1.0"
 
 aws-sdk-kms = { version = "0.10.1", optional = true }
 aws-config = { version = "0.10.1", optional = true }
+async-mutex = "1.4.0"
+
 
 [features]
 default = ["aws-kms", "cache"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -15,15 +15,19 @@ pub struct DataKey {
     pub key_id: String,
 }
 
-#[async_trait(?Send)]
-pub trait KeyProvider {
+#[async_trait]
+pub trait KeyProvider: Send + Sync {
     /// Generate a [`DataKey`] to encrypt a specific number of bytes
     ///
     /// # Arguments
     ///
     /// * `bytes_to_encrypt` - The number of bytes that this key will be used to encrypt
     ///
-    async fn generate_data_key(&self, bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError>;
+    async fn generate_data_key(
+        &self,
+        bytes_to_encrypt: usize,
+    ) -> Result<DataKey, KeyGenerationError>;
+
     /// Decrypt an encrypted key and return the plaintext key
     async fn decrypt_data_key(
         &self,
@@ -31,9 +35,12 @@ pub trait KeyProvider {
     ) -> Result<Key<U16>, KeyDecryptionError>;
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl KeyProvider for Box<dyn KeyProvider> {
-    async fn generate_data_key(&self, bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError> {
+    async fn generate_data_key(
+        &self,
+        bytes_to_encrypt: usize,
+    ) -> Result<DataKey, KeyGenerationError> {
         (**self).generate_data_key(bytes_to_encrypt).await
     }
 

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -59,7 +59,7 @@ impl KMSKeyProvider {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl KeyProvider for KMSKeyProvider {
     async fn generate_data_key(&self, _bytes_to_encrypt: usize) -> Result<DataKey, KeyGenerationError> {
         let mut response = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,9 +208,15 @@ impl<K: KeyProvider, R: SafeRng> EnvelopeCipher<K, R> {
 
 // Ensure that all supported EnvelopeCiphers can be shared between threads
 assert_impl_all!(EnvelopeCipher<SimpleKeyProvider>: Send, Sync);
-assert_impl_all!(EnvelopeCipher<KMSKeyProvider>: Send, Sync);
 assert_impl_all!(EnvelopeCipher<Box<dyn KeyProvider>>: Send, Sync);
+
+#[cfg(feature = "aws-kms")]
+assert_impl_all!(EnvelopeCipher<KMSKeyProvider>: Send, Sync);
+
+#[cfg(feature = "cache")]
 assert_impl_all!(EnvelopeCipher<CachingKeyWrapper<SimpleKeyProvider>>: Send, Sync);
+
+#[cfg(feature = "cache")]
 assert_impl_all!(EnvelopeCipher<CachingKeyWrapper<KMSKeyProvider>>: Send, Sync);
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@
 //! ```
 
 pub mod errors;
+pub mod safe_rng;
 
 mod key_provider;
 mod simple_key_provider;
@@ -109,10 +110,11 @@ pub use aes_gcm::Key;
 use aes_gcm::aead::{Aead, NewAead, Payload};
 use aes_gcm::{Aes128Gcm, Nonce};
 // Or `Aes256Gcm`
-use rand::{RngCore, SeedableRng};
+use async_mutex::Mutex as AsyncMutex;
 use rand_chacha::ChaChaRng;
+use safe_rng::SafeRng;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
+use static_assertions::assert_impl_all;
 
 pub use errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
 
@@ -134,32 +136,21 @@ impl EncryptedRecord {
     }
 }
 
-pub struct EnvelopeCipher<K, R = ChaChaRng>
-where
-    R: SeedableRng + RngCore,
-{
+pub struct EnvelopeCipher<K, R: SafeRng = ChaChaRng> {
     pub provider: K,
-    pub rng: RefCell<R>,
+    pub rng: AsyncMutex<R>,
 }
 
-impl<K, R> EnvelopeCipher<K, R>
-where
-    K: KeyProvider,
-    R: SeedableRng + RngCore,
-{
+impl<K, R: SafeRng> EnvelopeCipher<K, R> {
     pub fn init(provider: K) -> Self {
         Self {
             provider,
-            rng: RefCell::new(R::from_entropy()),
+            rng: AsyncMutex::new(R::from_entropy()),
         }
     }
 }
 
-impl<K, R> EnvelopeCipher<K, R>
-where
-    K: KeyProvider,
-    R: SeedableRng + RngCore,
-{
+impl<K: KeyProvider, R: SafeRng> EnvelopeCipher<K, R> {
     pub async fn decrypt(
         &self,
         encrypted_record: &EncryptedRecord,
@@ -189,7 +180,10 @@ where
 
         let key_id = data_key.key_id;
 
-        self.rng.borrow_mut().try_fill_bytes(&mut nonce_data)?;
+        {
+            let mut rng = self.rng.lock().await;
+            rng.try_fill_bytes(&mut nonce_data)?;
+        }
 
         let payload = Payload {
             msg,
@@ -211,6 +205,13 @@ where
         })
     }
 }
+
+// Ensure that all supported EnvelopeCiphers can be shared between threads
+assert_impl_all!(EnvelopeCipher<SimpleKeyProvider>: Send, Sync);
+assert_impl_all!(EnvelopeCipher<KMSKeyProvider>: Send, Sync);
+assert_impl_all!(EnvelopeCipher<Box<dyn KeyProvider>>: Send, Sync);
+assert_impl_all!(EnvelopeCipher<CachingKeyWrapper<SimpleKeyProvider>>: Send, Sync);
+assert_impl_all!(EnvelopeCipher<CachingKeyWrapper<KMSKeyProvider>>: Send, Sync);
 
 #[cfg(test)]
 mod tests {

--- a/src/safe_rng.rs
+++ b/src/safe_rng.rs
@@ -1,0 +1,5 @@
+use rand::{RngCore, SeedableRng};
+
+pub trait SafeRng: SeedableRng + RngCore + Send {}
+
+impl<T> SafeRng for T where T: SeedableRng + RngCore + Send {}


### PR DESCRIPTION
This is required for multi threaded async runtimes.

In the future we may be able to find a clever way to get around a few of these mutexes (async LRU caches, etc.) but since the mutexes are only locked when we need to insert data this shouldn't really lead to any performance issues.
