### PR TITLE
minor fix to envelopecipher aes type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,37 +8,33 @@ description = "A very simple envelope encryption library using aes-gcm"
 repository = "https://github.com/cipherstash/envelopers"
 
 [dev-dependencies]
-hex-literal = "0.3.2"
-hex = "0.4.3"
-tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread" ] }
-http = "0.2"
-base64 = "0.13.0"
-futures = "0.3.21"
-itertools = "0.10.3"
-
 aws-smithy-client = { version = "0.40.2", features = [ "test-util" ] }
 aws-smithy-http = "0.40.2"
+base64 = "0.13.0"
+futures = "0.3.21"
+hex = "0.4.3"
+hex-literal = "0.3.2"
+http = "0.2"
+itertools = "0.10.3"
+tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread" ] }
 
 [dependencies]
 aes-gcm = "0.10.1"
+async-mutex = "1.4.0"
+async-trait = "0.1.53"
+aws-config = { version = "0.10.1", optional = true }
+aws-sdk-kms = { version = "0.10.1", optional = true }
+lru = "0.7.5"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_cbor = "0.11.2"
-thiserror = "1.0.30"
-async-trait = "0.1.53"
-lru = "0.7.5"
-zeroize = { version = "1.5.7", features = [ "zeroize_derive" ] }
 static_assertions = "1.1.0"
-
-aws-sdk-kms = { version = "0.10.1", optional = true }
-aws-config = { version = "0.10.1", optional = true }
-async-mutex = "1.4.0"
-
+thiserror = "1.0.30"
+zeroize = { version = "1.5.7", features = [ "zeroize_derive" ] }
 
 [features]
 default = ["aws-kms", "cache"]
-# default = ["aws-kms"]
 aws-kms = ["dep:aws-sdk-kms", "dep:aws-config"]
 cache = []
 tokio = ["aws-sdk-kms?/rt-tokio"]


### PR DESCRIPTION
- fix the EnvelopeCipher.encrypt` should use same cipher type as generic param `S`
- add unit tests for `Aes256Gcm` to make sure everything works
- add unit tests for `Aes256Gcm` for SimpleKeyProvider as well
- sort the dependencies in Cargo.toml so it looks nicer