### PR TITLE
Feat/aes gcm siv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread" ] }
 
 [dependencies]
 aes-gcm = "0.10.1"
+aes-gcm-siv = "0.11.1"
 async-mutex = "1.4.0"
 async-trait = "0.1.53"
 aws-config = { version = "0.10.1", optional = true }

--- a/examples/kms-benchmark.rs
+++ b/examples/kms-benchmark.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .expect("Please export CS_KEY_ID environment variable with your AWS KMS key id."),
     );
 
-    let cipher: EnvelopeCipher<_, _> = EnvelopeCipher::init(CachingKeyWrapper::new(
+    let cipher: EnvelopeCipher<_> = EnvelopeCipher::init(CachingKeyWrapper::new(
         provider,
         CacheOptions::default()
             .with_max_age(Duration::from_secs(30))

--- a/examples/kms.rs
+++ b/examples/kms.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let provider = KMSKeyProvider::<Aes128Gcm>::new(client, std::env::var("CS_KEY_ID")?);
 
-    let cipher: EnvelopeCipher<_, _> = EnvelopeCipher::init(CachingKeyWrapper::new(
+    let cipher: EnvelopeCipher<_> = EnvelopeCipher::init(CachingKeyWrapper::new(
         provider,
         CacheOptions::default()
             .with_max_age(Duration::from_secs(30))

--- a/src/caching_key_wrapper.rs
+++ b/src/caching_key_wrapper.rs
@@ -1,9 +1,9 @@
-use aes_gcm::aead::Aead;
-use aes_gcm::{Key, KeyInit, KeySizeUser};
+use std::time::{Duration, Instant};
+
+use aes_gcm::{Key, KeySizeUser};
 use async_mutex::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use lru::LruCache;
-use std::time::{Duration, Instant};
 use zeroize::ZeroizeOnDrop;
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
@@ -203,8 +203,7 @@ where
 }
 
 #[async_trait]
-impl<S: KeyInit + KeySizeUser + Aead + Clone, K: KeyProvider<Cipher = S>> KeyProvider
-    for CachingKeyWrapper<S, K>
+impl<S: KeySizeUser + Clone, K: KeyProvider<Cipher = S>> KeyProvider for CachingKeyWrapper<S, K>
 where
     Key<S>: Copy,
 {

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -1,9 +1,6 @@
 //! Trait for a KeyProvider
 
-use aes_gcm::aead::Aead;
-use aes_gcm::Key;
-use aes_gcm::KeyInit;
-use aes_gcm::KeySizeUser;
+use aes_gcm::{Key, KeySizeUser};
 use async_trait::async_trait;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -40,7 +37,7 @@ pub trait KeyProvider: Send + Sync {
 }
 
 #[async_trait]
-impl<S: KeyInit + KeySizeUser + Aead> KeyProvider for Box<dyn KeyProvider<Cipher = S>> {
+impl<S: KeySizeUser> KeyProvider for Box<dyn KeyProvider<Cipher = S>> {
     type Cipher = S;
 
     async fn generate_data_key(

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -60,7 +60,9 @@ impl<S: KeySizeUser> KMSKeyProvider<S> {
 macro_rules! define_kms_key_provider_impl {
     ($name:ty, $data_key_spec:expr) => {
         #[async_trait]
-        impl KeyProvider<$name> for KMSKeyProvider<$name> {
+        impl KeyProvider for KMSKeyProvider<$name> {
+            type Cipher = $name;
+
             async fn generate_data_key(
                 &self,
                 _bytes_to_encrypt: usize,

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 use async_trait::async_trait;
 use aws_config::RetryConfig;
 use aws_sdk_kms::model::DataKeySpec;
@@ -133,6 +134,8 @@ macro_rules! define_kms_key_provider_impl {
 
 define_kms_key_provider_impl!(Aes128Gcm, DataKeySpec::Aes128);
 define_kms_key_provider_impl!(Aes256Gcm, DataKeySpec::Aes256);
+define_kms_key_provider_impl!(Aes128GcmSiv, DataKeySpec::Aes128);
+define_kms_key_provider_impl!(Aes256GcmSiv, DataKeySpec::Aes256);
 
 #[cfg(test)]
 mod tests {

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use aes_gcm::{Aes128Gcm, Aes256Gcm, Key, KeySizeUser};
 use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 use async_trait::async_trait;
 use aws_config::RetryConfig;
@@ -9,8 +10,6 @@ use aws_sdk_kms::{Client, Config, Credentials, Region};
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
 use crate::key_provider::{DataKey, KeyProvider};
-
-use aes_gcm::{Aes128Gcm, Aes256Gcm, Key, KeySizeUser};
 
 pub struct KMSKeyProvider<S: KeySizeUser = Aes128Gcm> {
     key_id: String,

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -12,7 +12,7 @@ use crate::key_provider::{DataKey, KeyProvider};
 
 use aes_gcm::{Aes128Gcm, Aes256Gcm, Key, KeySizeUser};
 
-pub struct KMSKeyProvider<S: KeySizeUser> {
+pub struct KMSKeyProvider<S: KeySizeUser = Aes128Gcm> {
     key_id: String,
     client: Client,
     phantom_data: PhantomData<S>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use crate::caching_key_wrapper::{CacheOptions, CachingKeyWrapper};
 pub use crate::kms_key_provider::KMSKeyProvider;
 
 pub use aes_gcm::{Aes128Gcm, Aes256Gcm, Key};
+pub use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
 pub use errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
 
@@ -221,6 +222,7 @@ assert_impl_all!(EnvelopeCipher<Aes128Gcm, CachingKeyWrapper<Aes128Gcm, KMSKeyPr
 #[cfg(test)]
 mod tests {
     use aes_gcm::{aead::Aead, Aes128Gcm, Aes256Gcm, KeyInit, KeySizeUser};
+    use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
     use crate::{CacheOptions, CachingKeyWrapper, EnvelopeCipher, KeyProvider, SimpleKeyProvider};
 
@@ -256,6 +258,30 @@ mod tests {
         let provider: SimpleKeyProvider<Aes256Gcm> = SimpleKeyProvider::init([1; 16]);
         let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
         let cipher: EnvelopeCipher<Aes256Gcm, _> = EnvelopeCipher::init(provider);
+        test_encrypt_decrypt(cipher).await;
+    }
+
+    #[tokio::test]
+    async fn test_encrypt_decrypt_128_gcm_siv() {
+        let provider: SimpleKeyProvider<Aes128GcmSiv> = SimpleKeyProvider::init([1; 16]);
+        let cipher: EnvelopeCipher<Aes128GcmSiv, _> = EnvelopeCipher::init(provider);
+        test_encrypt_decrypt(cipher).await;
+
+        let provider: SimpleKeyProvider<Aes128GcmSiv> = SimpleKeyProvider::init([1; 16]);
+        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let cipher: EnvelopeCipher<Aes128GcmSiv, _> = EnvelopeCipher::init(provider);
+        test_encrypt_decrypt(cipher).await;
+    }
+
+    #[tokio::test]
+    async fn test_encrypt_decrypt_256_gcm_siv() {
+        let provider: SimpleKeyProvider<Aes256GcmSiv> = SimpleKeyProvider::init([1; 16]);
+        let cipher: EnvelopeCipher<Aes256GcmSiv, _> = EnvelopeCipher::init(provider);
+        test_encrypt_decrypt(cipher).await;
+
+        let provider: SimpleKeyProvider<Aes256GcmSiv> = SimpleKeyProvider::init([1; 16]);
+        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let cipher: EnvelopeCipher<Aes256GcmSiv, _> = EnvelopeCipher::init(provider);
         test_encrypt_decrypt(cipher).await;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,10 @@ mod kms_key_provider;
 #[cfg(feature = "cache")]
 mod caching_key_wrapper;
 
+pub use aes_gcm::{Aes128Gcm, Aes256Gcm, Key, KeySizeUser};
+pub use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
+
+pub use crate::errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
 pub use crate::key_provider::{DataKey, KeyProvider};
 pub use crate::simple_key_provider::SimpleKeyProvider;
 
@@ -102,18 +106,14 @@ pub use crate::caching_key_wrapper::{CacheOptions, CachingKeyWrapper};
 #[cfg(feature = "aws-kms")]
 pub use crate::kms_key_provider::KMSKeyProvider;
 
-pub use aes_gcm::{Aes128Gcm, Aes256Gcm, Key};
-pub use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
-
-pub use errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
-
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{KeyInit, Nonce};
 use async_mutex::Mutex as AsyncMutex;
 use rand_chacha::ChaChaRng;
-use safe_rng::SafeRng;
 use serde::{Deserialize, Serialize};
 use static_assertions::assert_impl_all;
+
+use crate::safe_rng::SafeRng;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedRecord {

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -4,6 +4,7 @@ use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::aes::cipher::consts::U16;
 use aes_gcm::aes::Aes128;
 use aes_gcm::{Aes128Gcm, Aes256Gcm, AesGcm, Key, KeyInit, KeySizeUser};
+use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 use async_trait::async_trait;
 use rand_chacha::ChaChaRng;
 use std::marker::PhantomData;
@@ -147,10 +148,13 @@ macro_rules! define_simple_key_provider_impl {
 
 define_simple_key_provider_impl!(Aes128Gcm);
 define_simple_key_provider_impl!(Aes256Gcm);
+define_simple_key_provider_impl!(Aes128GcmSiv);
+define_simple_key_provider_impl!(Aes256GcmSiv);
 
 #[cfg(test)]
 mod tests {
     use aes_gcm::{Aes128Gcm, Aes256Gcm, KeySizeUser};
+    use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
     use super::{EncryptedSimpleKey, Nonce};
     use crate::{KeyProvider, SimpleKeyProvider};
@@ -188,6 +192,26 @@ mod tests {
         test_generate_decrypt_data_key(provider).await;
 
         let provider: SimpleKeyProvider<Aes256Gcm> = create_provider();
+        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        test_generate_decrypt_data_key(provider).await;
+    }
+
+    #[tokio::test]
+    async fn test_generate_decrypt_data_key_128_gcm_siv() {
+        let provider: SimpleKeyProvider<Aes128GcmSiv> = create_provider();
+        test_generate_decrypt_data_key(provider).await;
+
+        let provider: SimpleKeyProvider<Aes128GcmSiv> = create_provider();
+        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        test_generate_decrypt_data_key(provider).await;
+    }
+
+    #[tokio::test]
+    async fn test_generate_decrypt_data_key_256_gcm_siv() {
+        let provider: SimpleKeyProvider<Aes256GcmSiv> = create_provider();
+        test_generate_decrypt_data_key(provider).await;
+
+        let provider: SimpleKeyProvider<Aes256GcmSiv> = create_provider();
         let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
         test_generate_decrypt_data_key(provider).await;
     }

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -91,7 +91,9 @@ impl<S: KeySizeUser, R: SafeRng> SimpleKeyProvider<S, R> {
 macro_rules! define_simple_key_provider_impl {
     ($name:ty) => {
         #[async_trait]
-        impl<R: SafeRng> KeyProvider<$name> for SimpleKeyProvider<$name, R> {
+        impl<R: SafeRng> KeyProvider for SimpleKeyProvider<$name, R> {
+            type Cipher = $name;
+
             async fn decrypt_data_key(
                 &self,
                 encrypted_key: &[u8],
@@ -161,12 +163,14 @@ mod tests {
 
     fn create_provider<S: KeySizeUser>() -> SimpleKeyProvider<S>
     where
-        SimpleKeyProvider<S>: KeyProvider<S>,
+        SimpleKeyProvider<S>: KeyProvider<Cipher = S>,
     {
         SimpleKeyProvider::init([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
     }
 
-    async fn test_generate_decrypt_data_key<S: KeySizeUser, K: KeyProvider<S>>(provider: K) {
+    async fn test_generate_decrypt_data_key<S: KeySizeUser, K: KeyProvider<Cipher = S>>(
+        provider: K,
+    ) {
         let data_key = provider.generate_data_key(0).await.unwrap();
         let decrypted_data_key = provider
             .decrypt_data_key(&data_key.encrypted_key)
@@ -182,7 +186,7 @@ mod tests {
         test_generate_decrypt_data_key(provider).await;
 
         let provider: SimpleKeyProvider<Aes128Gcm> = create_provider();
-        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let provider: Box<dyn KeyProvider<Cipher = Aes128Gcm>> = Box::new(provider);
         test_generate_decrypt_data_key(provider).await;
     }
 
@@ -192,7 +196,7 @@ mod tests {
         test_generate_decrypt_data_key(provider).await;
 
         let provider: SimpleKeyProvider<Aes256Gcm> = create_provider();
-        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let provider: Box<dyn KeyProvider<Cipher = Aes256Gcm>> = Box::new(provider);
         test_generate_decrypt_data_key(provider).await;
     }
 
@@ -202,7 +206,7 @@ mod tests {
         test_generate_decrypt_data_key(provider).await;
 
         let provider: SimpleKeyProvider<Aes128GcmSiv> = create_provider();
-        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let provider: Box<dyn KeyProvider<Cipher = Aes128GcmSiv>> = Box::new(provider);
         test_generate_decrypt_data_key(provider).await;
     }
 
@@ -212,7 +216,7 @@ mod tests {
         test_generate_decrypt_data_key(provider).await;
 
         let provider: SimpleKeyProvider<Aes256GcmSiv> = create_provider();
-        let provider: Box<dyn KeyProvider<_>> = Box::new(provider);
+        let provider: Box<dyn KeyProvider<Cipher = Aes256GcmSiv>> = Box::new(provider);
         test_generate_decrypt_data_key(provider).await;
     }
 

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -70,7 +70,7 @@ impl<'a> EncryptedSimpleKey<'a> {
     }
 }
 
-pub struct SimpleKeyProvider<S: KeySizeUser, R: SafeRng = ChaChaRng> {
+pub struct SimpleKeyProvider<S: KeySizeUser = Aes128Gcm, R: SafeRng = ChaChaRng> {
     cipher: AesGcm<Aes128, U16>,
     rng: Mutex<R>,
     phantom_data: PhantomData<S>,

--- a/src/simple_key_provider.rs
+++ b/src/simple_key_provider.rs
@@ -1,5 +1,8 @@
 //! Trait for a KeyProvider
 
+use std::marker::PhantomData;
+use std::sync::Mutex;
+
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::aes::cipher::consts::U16;
 use aes_gcm::aes::Aes128;
@@ -7,8 +10,6 @@ use aes_gcm::{Aes128Gcm, Aes256Gcm, AesGcm, Key, KeyInit, KeySizeUser};
 use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 use async_trait::async_trait;
 use rand_chacha::ChaChaRng;
-use std::marker::PhantomData;
-use std::sync::Mutex;
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
 use crate::key_provider::{DataKey, KeyProvider};


### PR DESCRIPTION
- add support for `Aes128GcmSiv` and `Aes256GcmSiv` cipher types
- make `Aes128Gcm` the default in `EnvelopeCipher`, `SimpleKeyProvider` and `KmsKeyProvider`
- add Cipher assoc type to `KeyProvider`, and simplify generic param for `EnveloperCipher`