### PR TITLE
Add bulk operations for key provider

### DIFF
--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -114,6 +114,7 @@ mod tests {
             .await
             .expect("Failed to decrypt keys");
 
+        assert_ne!(keys[0], keys[1]);
         assert_eq!(keys, decrypted_keys);
     }
 }

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -27,7 +27,7 @@ pub trait KeyProvider: Send + Sync {
     ///
     /// # Arguments
     ///
-    /// * `bytes_to_encrypt` - The number of bytes that this key will be used to encrypt
+    /// * `spec` - [`GenerateKeySpec`] containing the number of bytes that this key will be used to encrypt
     ///
     async fn generate_data_key(
         &self,
@@ -40,6 +40,7 @@ pub trait KeyProvider: Send + Sync {
         encrypted_key: &[u8],
     ) -> Result<Key<Self::Cipher>, KeyDecryptionError>;
 
+    /// Generate multiple [`DataKey`] for a slice of [`GenerateKeySpec`]
     async fn generate_many_data_keys(
         &self,
         specs: &[GenerateKeySpec],
@@ -53,6 +54,7 @@ pub trait KeyProvider: Send + Sync {
         Ok(output)
     }
 
+    /// Decrypt multiple encrypted keys and return their plaintext keys
     async fn decrypt_many_data_keys(
         &self,
         encrypted_keys: &[Vec<u8>],

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -6,6 +6,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
 
+#[derive(Clone, Copy, Debug)]
+pub struct GenerateKeySpec {
+    pub bytes_to_encrypt: usize,
+}
+
 #[derive(Debug, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct DataKey<S: KeySizeUser> {
     pub key: Key<S>,
@@ -26,7 +31,7 @@ pub trait KeyProvider: Send + Sync {
     ///
     async fn generate_data_key(
         &self,
-        bytes_to_encrypt: usize,
+        spec: GenerateKeySpec,
     ) -> Result<DataKey<Self::Cipher>, KeyGenerationError>;
 
     /// Decrypt an encrypted key and return the plaintext key
@@ -34,6 +39,32 @@ pub trait KeyProvider: Send + Sync {
         &self,
         encrypted_key: &[u8],
     ) -> Result<Key<Self::Cipher>, KeyDecryptionError>;
+
+    async fn generate_many_data_keys(
+        &self,
+        specs: &[GenerateKeySpec],
+    ) -> Result<Vec<DataKey<Self::Cipher>>, KeyGenerationError> {
+        let mut output = Vec::with_capacity(specs.len());
+
+        for spec in specs {
+            output.push(self.generate_data_key(*spec).await?);
+        }
+
+        Ok(output)
+    }
+
+    async fn decrypt_many_data_keys(
+        &self,
+        encrypted_keys: &[Vec<u8>],
+    ) -> Result<Vec<Key<Self::Cipher>>, KeyDecryptionError> {
+        let mut output = Vec::with_capacity(encrypted_keys.len());
+
+        for key in encrypted_keys {
+            output.push(self.decrypt_data_key(key).await?);
+        }
+
+        Ok(output)
+    }
 }
 
 #[async_trait]
@@ -42,12 +73,45 @@ impl<S: KeySizeUser> KeyProvider for Box<dyn KeyProvider<Cipher = S>> {
 
     async fn generate_data_key(
         &self,
-        bytes_to_encrypt: usize,
+        spec: GenerateKeySpec,
     ) -> Result<DataKey<S>, KeyGenerationError> {
-        (**self).generate_data_key(bytes_to_encrypt).await
+        (**self).generate_data_key(spec).await
     }
 
     async fn decrypt_data_key(&self, encrypted_key: &[u8]) -> Result<Key<S>, KeyDecryptionError> {
         (**self).decrypt_data_key(encrypted_key).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GenerateKeySpec, KeyProvider};
+    use crate::SimpleKeyProvider;
+
+    #[tokio::test]
+    async fn test_round_trip_many_keys() {
+        let provider: SimpleKeyProvider = SimpleKeyProvider::init([1; 16]);
+
+        let keys = provider
+            .generate_many_data_keys(&vec![
+                GenerateKeySpec {
+                    bytes_to_encrypt: 100
+                };
+                100
+            ])
+            .await
+            .expect("Failed to generate keys");
+
+        let (keys, encrypted_keys): (Vec<_>, Vec<_>) = keys
+            .into_iter()
+            .map(|key| (key.key, key.encrypted_key.clone()))
+            .unzip();
+
+        let decrypted_keys = provider
+            .decrypt_many_data_keys(encrypted_keys.as_slice())
+            .await
+            .expect("Failed to decrypt keys");
+
+        assert_eq!(keys, decrypted_keys);
     }
 }

--- a/src/kms_key_provider.rs
+++ b/src/kms_key_provider.rs
@@ -9,7 +9,7 @@ use aws_sdk_kms::types::Blob;
 use aws_sdk_kms::{Client, Config, Credentials, Region};
 
 use crate::errors::{KeyDecryptionError, KeyGenerationError};
-use crate::key_provider::{DataKey, KeyProvider};
+use crate::key_provider::{DataKey, KeyProvider, GenerateKeySpec};
 
 pub struct KMSKeyProvider<S: KeySizeUser = Aes128Gcm> {
     key_id: String,
@@ -64,7 +64,7 @@ macro_rules! define_kms_key_provider_impl {
 
             async fn generate_data_key(
                 &self,
-                _bytes_to_encrypt: usize,
+                _spec: GenerateKeySpec,
             ) -> Result<DataKey<$name>, KeyGenerationError> {
                 let mut response = self
                     .client
@@ -149,7 +149,7 @@ mod tests {
     use core::future::Future;
     use http::{Request, Response, StatusCode};
 
-    use crate::{KMSKeyProvider, KeyProvider};
+    use crate::{KMSKeyProvider, KeyProvider, GenerateKeySpec};
 
     async fn with_mocked_response<C, F>(
         request_body: impl Into<String>,
@@ -211,7 +211,7 @@ mod tests {
                 let provider = KMSKeyProvider::<Aes128Gcm>::new(client, key_id.into());
 
                 let key = provider
-                    .generate_data_key(0)
+                    .generate_data_key(GenerateKeySpec { bytes_to_encrypt: 0 })
                     .await
                     .expect("Failed to generate data key");
 
@@ -234,7 +234,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::<Aes128Gcm>::new(client, key_id.into());
 
-                let result = provider.generate_data_key(0).await;
+                let result = provider.generate_data_key(GenerateKeySpec { bytes_to_encrypt: 0 }).await;
 
                 match result {
                     Ok(_) => panic!("Expected result to be an error"),
@@ -261,7 +261,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::<Aes128Gcm>::new(client, key_id.into());
 
-                let result = provider.generate_data_key(0).await;
+                let result = provider.generate_data_key(GenerateKeySpec { bytes_to_encrypt: 0 }).await;
 
                 match result {
                     Ok(_) => panic!("Expected result to be an error"),
@@ -289,7 +289,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::<Aes128Gcm>::new(client, key_id.into());
 
-                let result = provider.generate_data_key(0).await;
+                let result = provider.generate_data_key(GenerateKeySpec { bytes_to_encrypt: 0 }).await;
 
                 match result {
                     Ok(_) => panic!("Expected result to be an error"),
@@ -311,7 +311,7 @@ mod tests {
             |client| async move {
                 let provider = KMSKeyProvider::<Aes128Gcm>::new(client, key_id.into());
 
-                let result = provider.generate_data_key(0).await;
+                let result = provider.generate_data_key(GenerateKeySpec { bytes_to_encrypt: 0 }).await;
 
                 match result {
                     Ok(_) => panic!("Expected result to be an error"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use aes_gcm::{Aes128Gcm, Aes256Gcm, Key, KeySizeUser};
 pub use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
 pub use crate::errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
-pub use crate::key_provider::{DataKey, KeyProvider};
+pub use crate::key_provider::{DataKey, GenerateKeySpec, KeyProvider};
 pub use crate::simple_key_provider::SimpleKeyProvider;
 
 #[cfg(feature = "cache")]
@@ -174,7 +174,12 @@ where
     }
 
     pub async fn encrypt(&self, msg: &[u8]) -> Result<EncryptedRecord, EncryptionError> {
-        let data_key = self.provider.generate_data_key(msg.len()).await?;
+        let data_key = self
+            .provider
+            .generate_data_key(GenerateKeySpec {
+                bytes_to_encrypt: msg.len(),
+            })
+            .await?;
         let key_id = data_key.key_id.clone();
 
         let mut nonce_data = [0u8; 12];


### PR DESCRIPTION
Modifies the `KeyProvider` to support bulk generate and decrypt key calls. This includes an automatic definition so that providers can opt into this behavior and not be required to implement it.

This PR doesn't actually include any code for bulk encrypt/decryption - this is just the key provider side.