### PR TITLE
Update AWS-related dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 readme = "README.md"
@@ -8,8 +8,8 @@ description = "A very simple envelope encryption library using aes-gcm"
 repository = "https://github.com/cipherstash/envelopers"
 
 [dev-dependencies]
-aws-smithy-client = { version = "0.40.2", features = [ "test-util" ] }
-aws-smithy-http = "0.40.2"
+aws-smithy-client = { version = "0.56.1", features = [ "test-util" ] }
+aws-smithy-http = "0.56.1"
 base64 = "0.13.0"
 futures = "0.3.21"
 hex = "0.4.3"
@@ -23,8 +23,8 @@ aes-gcm = "0.10.1"
 aes-gcm-siv = "0.11.1"
 async-mutex = "1.4.0"
 async-trait = "0.1.53"
-aws-config = { version = "0.10.1", optional = true }
-aws-sdk-kms = { version = "0.10.1", optional = true }
+aws-config = { version = "0.56.1", optional = true }
+aws-sdk-kms = { version = "0.33.0", optional = true }
 lru = "0.7.5"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/src/caching_key_wrapper.rs
+++ b/src/caching_key_wrapper.rs
@@ -522,7 +522,7 @@ mod tests {
 
         assert_eq!(cache.provider.get_decrypt_count(), 1);
 
-        std::thread::sleep(Duration::from_millis(8));
+        std::thread::sleep(Duration::from_millis(5));
 
         assert!(cache
             .decrypt_data_key(&test_encrypt_bytes(&key, None), None)


### PR DESCRIPTION
The envelopers crate has incompatible deps to be used with IDP when pulled into monorepo. This updates and makes updates for some API changes